### PR TITLE
Pass TLS objects (with e.g. LDAP_REQUIRE_CERT parameter) into Server …

### DIFF
--- a/flask_ldapconn/__init__.py
+++ b/flask_ldapconn/__init__.py
@@ -48,6 +48,7 @@ class LDAPConn(object):
             host=app.config['LDAP_SERVER'],
             port=app.config['LDAP_PORT'],
             use_ssl=app.config['LDAP_USE_SSL'],
+            tls=self.tls,
             get_info=GET_ALL_INFO
         )
 


### PR DESCRIPTION
…object. Minimally, but far from completely addresses #14.