### PR TITLE
Add feature to return string values in JSON object

### DIFF
--- a/flask_ldapconn/entry.py
+++ b/flask_ldapconn/entry.py
@@ -181,10 +181,19 @@ class LDAPEntry(object):
         '''
         return self.connection.authenticate(self.dn, password)
 
-    def to_json(self, indent=2, sort=True):
+    def to_json(self, indent=2, sort=True, str_values=False):
         json_entry = dict()
         json_entry['dn'] = self.dn
-        json_entry['attributes'] = self.get_attributes_dict()
+
+        # Get "single values" from attributes as str instead list if
+        # `str_values=True` else get all attributes as list. This only
+        # works if `FORCE_ATTRIBUTE_VALUE_AS_LIST` is False (default).
+        if str_values is True:
+            json_entry['attributes'] = {}
+            for attr in self._attributes.keys():
+                json_entry['attributes'][attr] = self._attributes[attr].value
+        else:
+            json_entry['attributes'] = self.get_attributes_dict()
 
         if str == bytes:
             check_json_dict(json_entry)

--- a/test_flask_ldapconn.py
+++ b/test_flask_ldapconn.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import ssl
+import json
 import time
 import random
 import string
@@ -37,6 +38,14 @@ LDAP_AUTH_SEARCH_FILTER = '(objectClass=inetOrgPerson)'
 UID_SUFFIX = ''.join(random.choice(
     string.ascii_lowercase + string.digits
 ) for _ in range(6))
+
+
+def is_json(myjson):
+    try:
+        json.loads(myjson)
+    except (ValueError, TypeError):
+        return False
+    return True
 
 
 class User(LDAPEntry):
@@ -213,18 +222,14 @@ class LDAPConnModelTestCase(unittest.TestCase):
                 self.assertTrue(isinstance(attr_dict[attr], list))
 
     def test_model_to_json(self):
-        import json
-
-        def is_json(myjson):
-            try:
-                json.loads(myjson)
-            except (ValueError, TypeError):
-                return False
-            return True
-
         with self.app.test_request_context():
             user = self.user.query.filter('userid: bender').first()
             self.assertTrue(is_json(user.to_json()))
+
+    def test_model_to_json_str_values(self):
+        with self.app.test_request_context():
+            user = self.user.query.filter('userid: bender').first()
+            self.assertTrue(is_json(user.to_json(str_values=True)))
 
     def test_model_iter(self):
         with self.app.test_request_context():


### PR DESCRIPTION
With this commit it is possible to get string values in JSON
object, if the LDAP attribute has only one value. To not break
compatibility this feature has to be turned on with:

    `Entry.to_json(str_values=True)`

Related issue #31.