### PR TITLE
Add connection timeout support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Your configuration should be declared within your Flask config. Sample configura
     LDAP_PORT = 389
     LDAP_BINDDN = 'cn=admin,dc=example,dc=com'
     LDAP_SECRET = 'forty-two'
-    LDAP_TIMEOUT = 10
+    LDAP_CONNECT_TIMEOUT = 10  # Honored when the TCP connection is being established
     LDAP_USE_TLS = True  # default
     LDAP_REQUIRE_CERT = ssl.CERT_NONE  # default: CERT_REQUIRED
     LDAP_TLS_VERSION = ssl.PROTOCOL_TLSv1_2  # default: PROTOCOL_TLSv1

--- a/flask_ldapconn/__init__.py
+++ b/flask_ldapconn/__init__.py
@@ -36,7 +36,7 @@ class LDAPConn(object):
         app.config.setdefault('LDAP_PORT', 389)
         app.config.setdefault('LDAP_BINDDN', None)
         app.config.setdefault('LDAP_SECRET', None)
-        app.config.setdefault('LDAP_TIMEOUT', 10)
+        app.config.setdefault('LDAP_CONNECT_TIMEOUT', 10)
         app.config.setdefault('LDAP_READ_ONLY', False)
         app.config.setdefault('LDAP_VALID_NAMES', None)
         app.config.setdefault('LDAP_PRIVATE_KEY_PASSWORD', None)
@@ -74,6 +74,7 @@ class LDAPConn(object):
             host=app.config['LDAP_SERVER'],
             port=app.config['LDAP_PORT'],
             use_ssl=app.config['LDAP_USE_SSL'],
+            connect_timeout=app.config['LDAP_CONNECT_TIMEOUT'],
             tls=self.tls,
             get_info=ALL
         )


### PR DESCRIPTION
Renames `LDAP_TIMEOUT` to `LDAP_CONNECT_TIMEOUT`  so it won't get mixed up with `Connection.receive_timeout`.

The old option, `LDAP_TIMEOUT`, was never actually used in `Server.connect_timeout`, so this shouldn't cause any breakage.

The default value of this parameter in `ldap3` is set to None (indefinite).
