### PR TITLE
Task #38 No caching works through pickle

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,19 +1,15 @@
 [[source]]
-
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
-
 [packages]
-
-flask = "*"
-"ldap3" = "*"
-six = "*"
-
+ldap3 = ">=2.3"
+six = ">=1.10"
+Flask = ">=0.12"
 
 [dev-packages]
-
 docker = "*"
 pytest = "*"
 coverage = "*"
+pathlib2 = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1e543f60e9e9a1aee8cd7012c8f33a82b2dc0dcee6cdb59a947e55a8e7284a3d"
+            "sha256": "6c85c45a9fea24d5b3f1b1d1f51ccdcfd982ac425dcba5e2acf80e550cb1c0aa"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -45,50 +45,51 @@
         },
         "ldap3": {
             "hashes": [
-                "sha256:cc09951809678cfb693a13a6011dd2d48ada60a52bd80cb4bd7dcc55ee7c02fd"
+                "sha256:3f67c83185b1f0df8fdf6b52fa42c55bc9e9b7120c8b7fec60f0d6003c536d18",
+                "sha256:dd9be8ea27773c4ffc18ede0b95c3ca1eb12513a184590b9f8ae423db3f71eb9"
             ],
             "index": "pypi",
-            "version": "==2.5.1"
+            "version": "==2.5.2"
         },
         "markupsafe": {
             "hashes": [
-                "sha256:048ef924c1623740e70204aa7143ec592504045ae4429b59c30054cb31e3c432",
-                "sha256:130f844e7f5bdd8e9f3f42e7102ef1d49b2e6fdf0d7526df3f87281a532d8c8b",
-                "sha256:19f637c2ac5ae9da8bfd98cef74d64b7e1bb8a63038a3505cd182c3fac5eb4d9",
-                "sha256:1b8a7a87ad1b92bd887568ce54b23565f3fd7018c4180136e1cf412b405a47af",
-                "sha256:1c25694ca680b6919de53a4bb3bdd0602beafc63ff001fea2f2fc16ec3a11834",
-                "sha256:1f19ef5d3908110e1e891deefb5586aae1b49a7440db952454b4e281b41620cd",
-                "sha256:1fa6058938190ebe8290e5cae6c351e14e7bb44505c4a7624555ce57fbbeba0d",
-                "sha256:31cbb1359e8c25f9f48e156e59e2eaad51cd5242c05ed18a8de6dbe85184e4b7",
-                "sha256:3e835d8841ae7863f64e40e19477f7eb398674da6a47f09871673742531e6f4b",
-                "sha256:4e97332c9ce444b0c2c38dd22ddc61c743eb208d916e4265a2a3b575bdccb1d3",
-                "sha256:525396ee324ee2da82919f2ee9c9e73b012f23e7640131dd1b53a90206a0f09c",
-                "sha256:52b07fbc32032c21ad4ab060fec137b76eb804c4b9a1c7c7dc562549306afad2",
-                "sha256:52ccb45e77a1085ec5461cde794e1aa037df79f473cbc69b974e73940655c8d7",
-                "sha256:5c3fbebd7de20ce93103cb3183b47671f2885307df4a17a0ad56a1dd51273d36",
-                "sha256:5e5851969aea17660e55f6a3be00037a25b96a9b44d2083651812c99d53b14d1",
-                "sha256:5edfa27b2d3eefa2210fb2f5d539fbed81722b49f083b2c6566455eb7422fd7e",
-                "sha256:7d263e5770efddf465a9e31b78362d84d015cc894ca2c131901a4445eaa61ee1",
-                "sha256:83381342bfc22b3c8c06f2dd93a505413888694302de25add756254beee8449c",
-                "sha256:857eebb2c1dc60e4219ec8e98dfa19553dae33608237e107db9c6078b1167856",
-                "sha256:98e439297f78fca3a6169fd330fbe88d78b3bb72f967ad9961bcac0d7fdd1550",
-                "sha256:bf54103892a83c64db58125b3f2a43df6d2cb2d28889f14c78519394feb41492",
-                "sha256:d9ac82be533394d341b41d78aca7ed0e0f4ba5a2231602e2f05aa87f25c51672",
-                "sha256:e982fe07ede9fada6ff6705af70514a52beb1b2c3d25d4e873e82114cf3c5401",
-                "sha256:edce2ea7f3dfc981c4ddc97add8a61381d9642dc3273737e756517cc03e84dd6",
-                "sha256:efdc45ef1afc238db84cb4963aa689c0408912a0239b0721cb172b4016eb31d6",
-                "sha256:f137c02498f8b935892d5c0172560d7ab54bc45039de8805075e19079c639a9c",
-                "sha256:f82e347a72f955b7017a39708a3667f106e6ad4d10b25f237396a7115d8ed5fd",
-                "sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1"
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
             ],
-            "version": "==1.1.0"
+            "version": "==1.1.1"
         },
         "pyasn1": {
             "hashes": [
-                "sha256:b9d3abc5031e61927c82d4d96c1cec1e55676c1a991623cfed28faea73cdd7ca",
-                "sha256:f58f2a3d12fd754aa123e9fa74fb7345333000a035f3921dbdaa08597aa53137"
+                "sha256:da2420fe13a9452d8ae97a0e478adde1dee153b11ba832a95b223a2ba01c10f7",
+                "sha256:da6b43a8c9ae93bc80e2739efb38cc776ba74a886e3e9318d65fe81a8b8a2c6e"
             ],
-            "version": "==0.4.4"
+            "version": "==0.4.5"
         },
         "six": {
             "hashes": [
@@ -109,24 +110,30 @@
     "develop": {
         "atomicwrites": {
             "hashes": [
-                "sha256:0312ad34fcad8fac3704d441f7b317e50af620823353ec657a53e981f92920c0",
-                "sha256:ec9ae8adaae229e4f8446952d204a3e4b5fdd2d099f9be3aaf556120135fb3ee"
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
             ],
-            "version": "==1.2.1"
+            "version": "==1.3.0"
         },
         "attrs": {
             "hashes": [
-                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
-                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
-            "version": "==18.2.0"
+            "version": "==19.1.0"
+        },
+        "backports.ssl-match-hostname": {
+            "hashes": [
+                "sha256:bb82e60f9fbf4c080eabd957c39f0641f0fc247d9a16e31e26d594d8f42b9fd2"
+            ],
+            "version": "==3.7.0.1"
         },
         "certifi": {
             "hashes": [
-                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
-                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
             ],
-            "version": "==2018.11.29"
+            "version": "==2019.3.9"
         },
         "chardet": {
             "hashes": [
@@ -137,48 +144,48 @@
         },
         "coverage": {
             "hashes": [
-                "sha256:09e47c529ff77bf042ecfe858fb55c3e3eb97aac2c87f0349ab5a7efd6b3939f",
-                "sha256:0a1f9b0eb3aa15c990c328535655847b3420231af299386cfe5efc98f9c250fe",
-                "sha256:0cc941b37b8c2ececfed341444a456912e740ecf515d560de58b9a76562d966d",
-                "sha256:10e8af18d1315de936d67775d3a814cc81d0747a1a0312d84e27ae5610e313b0",
-                "sha256:1b4276550b86caa60606bd3572b52769860a81a70754a54acc8ba789ce74d607",
-                "sha256:1e8a2627c48266c7b813975335cfdea58c706fe36f607c97d9392e61502dc79d",
-                "sha256:2b224052bfd801beb7478b03e8a66f3f25ea56ea488922e98903914ac9ac930b",
-                "sha256:447c450a093766744ab53bf1e7063ec82866f27bcb4f4c907da25ad293bba7e3",
-                "sha256:46101fc20c6f6568561cdd15a54018bb42980954b79aa46da8ae6f008066a30e",
-                "sha256:4710dc676bb4b779c4361b54eb308bc84d64a2fa3d78e5f7228921eccce5d815",
-                "sha256:510986f9a280cd05189b42eee2b69fecdf5bf9651d4cd315ea21d24a964a3c36",
-                "sha256:5535dda5739257effef56e49a1c51c71f1d37a6e5607bb25a5eee507c59580d1",
-                "sha256:5a7524042014642b39b1fcae85fb37556c200e64ec90824ae9ecf7b667ccfc14",
-                "sha256:5f55028169ef85e1fa8e4b8b1b91c0b3b0fa3297c4fb22990d46ff01d22c2d6c",
-                "sha256:6694d5573e7790a0e8d3d177d7a416ca5f5c150742ee703f3c18df76260de794",
-                "sha256:6831e1ac20ac52634da606b658b0b2712d26984999c9d93f0c6e59fe62ca741b",
-                "sha256:77f0d9fa5e10d03aa4528436e33423bfa3718b86c646615f04616294c935f840",
-                "sha256:828ad813c7cdc2e71dcf141912c685bfe4b548c0e6d9540db6418b807c345ddd",
-                "sha256:85a06c61598b14b015d4df233d249cd5abfa61084ef5b9f64a48e997fd829a82",
-                "sha256:8cb4febad0f0b26c6f62e1628f2053954ad2c555d67660f28dfb1b0496711952",
-                "sha256:a5c58664b23b248b16b96253880b2868fb34358911400a7ba39d7f6399935389",
-                "sha256:aaa0f296e503cda4bc07566f592cd7a28779d433f3a23c48082af425d6d5a78f",
-                "sha256:ab235d9fe64833f12d1334d29b558aacedfbca2356dfb9691f2d0d38a8a7bfb4",
-                "sha256:b3b0c8f660fae65eac74fbf003f3103769b90012ae7a460863010539bb7a80da",
-                "sha256:bab8e6d510d2ea0f1d14f12642e3f35cefa47a9b2e4c7cea1852b52bc9c49647",
-                "sha256:c45297bbdbc8bb79b02cf41417d63352b70bcb76f1bbb1ee7d47b3e89e42f95d",
-                "sha256:d19bca47c8a01b92640c614a9147b081a1974f69168ecd494687c827109e8f42",
-                "sha256:d64b4340a0c488a9e79b66ec9f9d77d02b99b772c8b8afd46c1294c1d39ca478",
-                "sha256:da969da069a82bbb5300b59161d8d7c8d423bc4ccd3b410a9b4d8932aeefc14b",
-                "sha256:ed02c7539705696ecb7dc9d476d861f3904a8d2b7e894bd418994920935d36bb",
-                "sha256:ee5b8abc35b549012e03a7b1e86c09491457dba6c94112a2482b18589cc2bdb9"
+                "sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9",
+                "sha256:39e088da9b284f1bd17c750ac672103779f7954ce6125fd4382134ac8d152d74",
+                "sha256:3c205bc11cc4fcc57b761c2da73b9b72a59f8d5ca89979afb0c1c6f9e53c7390",
+                "sha256:465ce53a8c0f3a7950dfb836438442f833cf6663d407f37d8c52fe7b6e56d7e8",
+                "sha256:48020e343fc40f72a442c8a1334284620f81295256a6b6ca6d8aa1350c763bbe",
+                "sha256:5296fc86ab612ec12394565c500b412a43b328b3907c0d14358950d06fd83baf",
+                "sha256:5f61bed2f7d9b6a9ab935150a6b23d7f84b8055524e7be7715b6513f3328138e",
+                "sha256:68a43a9f9f83693ce0414d17e019daee7ab3f7113a70c79a3dd4c2f704e4d741",
+                "sha256:6b8033d47fe22506856fe450470ccb1d8ba1ffb8463494a15cfc96392a288c09",
+                "sha256:7ad7536066b28863e5835e8cfeaa794b7fe352d99a8cded9f43d1161be8e9fbd",
+                "sha256:7bacb89ccf4bedb30b277e96e4cc68cd1369ca6841bde7b005191b54d3dd1034",
+                "sha256:839dc7c36501254e14331bcb98b27002aa415e4af7ea039d9009409b9d2d5420",
+                "sha256:8f9a95b66969cdea53ec992ecea5406c5bd99c9221f539bca1e8406b200ae98c",
+                "sha256:932c03d2d565f75961ba1d3cec41ddde00e162c5b46d03f7423edcb807734eab",
+                "sha256:988529edadc49039d205e0aa6ce049c5ccda4acb2d6c3c5c550c17e8c02c05ba",
+                "sha256:998d7e73548fe395eeb294495a04d38942edb66d1fa61eb70418871bc621227e",
+                "sha256:9de60893fb447d1e797f6bf08fdf0dbcda0c1e34c1b06c92bd3a363c0ea8c609",
+                "sha256:9e80d45d0c7fcee54e22771db7f1b0b126fb4a6c0a2e5afa72f66827207ff2f2",
+                "sha256:a545a3dfe5082dc8e8c3eb7f8a2cf4f2870902ff1860bd99b6198cfd1f9d1f49",
+                "sha256:a5d8f29e5ec661143621a8f4de51adfb300d7a476224156a39a392254f70687b",
+                "sha256:aca06bfba4759bbdb09bf52ebb15ae20268ee1f6747417837926fae990ebc41d",
+                "sha256:bb23b7a6fd666e551a3094ab896a57809e010059540ad20acbeec03a154224ce",
+                "sha256:bfd1d0ae7e292105f29d7deaa9d8f2916ed8553ab9d5f39ec65bcf5deadff3f9",
+                "sha256:c62ca0a38958f541a73cf86acdab020c2091631c137bd359c4f5bddde7b75fd4",
+                "sha256:c709d8bda72cf4cd348ccec2a4881f2c5848fd72903c185f363d361b2737f773",
+                "sha256:c968a6aa7e0b56ecbd28531ddf439c2ec103610d3e2bf3b75b813304f8cb7723",
+                "sha256:df785d8cb80539d0b55fd47183264b7002077859028dfe3070cf6359bf8b2d9c",
+                "sha256:f406628ca51e0ae90ae76ea8398677a921b36f0bd71aab2099dfed08abd0322f",
+                "sha256:f46087bbd95ebae244a0eda01a618aff11ec7a069b15a3ef8f6b520db523dcf1",
+                "sha256:f8019c5279eb32360ca03e9fac40a12667715546eed5c5eb59eb381f2f501260",
+                "sha256:fc5f4d209733750afd2714e9109816a29500718b32dd9a5db01c0cb3a019b96a"
             ],
             "index": "pypi",
-            "version": "==4.5.2"
+            "version": "==4.5.3"
         },
         "docker": {
             "hashes": [
-                "sha256:145c673f531df772a957bd1ebc49fc5a366bcd55efa0e64bbd029f5cc7a1fd8e",
-                "sha256:666611862edded75f6049893f779bff629fdcd4cd21ccf01d648626e709adb13"
+                "sha256:2840ffb9dc3ef6d00876bde476690278ab13fa1f8ba9127ef855ac33d00c3152",
+                "sha256:5831256da3477723362bc71a8df07b8cd8493e4a4a60cebd45580483edbe48ae"
             ],
             "index": "pypi",
-            "version": "==3.6.0"
+            "version": "==3.7.0"
         },
         "docker-pycreds": {
             "hashes": [
@@ -187,6 +194,13 @@
             ],
             "version": "==0.4.0"
         },
+        "funcsigs": {
+            "hashes": [
+                "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
+                "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
+            ],
+            "version": "==1.0.2"
+        },
         "idna": {
             "hashes": [
                 "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
@@ -194,35 +208,50 @@
             ],
             "version": "==2.8"
         },
+        "ipaddress": {
+            "hashes": [
+                "sha256:64b28eec5e78e7510698f6d4da08800a5c575caa4a286c93d651c5d3ff7b6794",
+                "sha256:b146c751ea45cad6188dd6cf2d9b757f6f4f8d6ffb96a023e6f2e26eea02a72c"
+            ],
+            "version": "==1.0.22"
+        },
         "more-itertools": {
             "hashes": [
-                "sha256:c187a73da93e7a8acc0001572aebc7e3c69daf7bf6881a2cea10650bd4420092",
-                "sha256:c476b5d3a34e12d40130bc2f935028b5f636df8f372dc2c1c01dc19681b2039e",
-                "sha256:fcbfeaea0be121980e15bc97b3817b5202ca73d0eae185b4550cbfce2a3ebb3d"
+                "sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4",
+                "sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc",
+                "sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9"
             ],
-            "version": "==4.3.0"
+            "version": "==5.0.0"
+        },
+        "pathlib2": {
+            "hashes": [
+                "sha256:25199318e8cc3c25dcb45cbe084cc061051336d5a9ea2a12448d3d8cb748f742",
+                "sha256:5887121d7f7df3603bca2f710e7219f3eca0eb69e0b7cc6e0a022e155ac931a7"
+            ],
+            "index": "pypi",
+            "version": "==2.3.3"
         },
         "pluggy": {
             "hashes": [
-                "sha256:447ba94990e8014ee25ec853339faf7b0fc8050cdc3289d4d71f7f410fb90095",
-                "sha256:bde19360a8ec4dfd8a20dcb811780a30998101f078fc7ded6162f0076f50508f"
+                "sha256:19ecf9ce9db2fce065a7a0586e07cfb4ac8614fe96edf628a264b1c70116cf8f",
+                "sha256:84d306a647cc805219916e62aab89caa97a33a1dd8c342e87a37f91073cd4746"
             ],
-            "version": "==0.8.0"
+            "version": "==0.9.0"
         },
         "py": {
             "hashes": [
-                "sha256:bf92637198836372b520efcba9e020c330123be8ce527e535d185ed4b6f45694",
-                "sha256:e76826342cefe3c3d5f7e8ee4316b80d1dd8a300781612ddbc765c17ba25a6c6"
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
             ],
-            "version": "==1.7.0"
+            "version": "==1.8.0"
         },
         "pytest": {
             "hashes": [
-                "sha256:1d131cc532be0023ef8ae265e2a779938d0619bb6c2510f52987ffcba7fa1ee4",
-                "sha256:ca4761407f1acc85ffd1609f464ca20bb71a767803505bd4127d0e45c5a50e23"
+                "sha256:592eaa2c33fae68c7d75aacf042efc9f77b27c08a6224a4f59beab8d9a420523",
+                "sha256:ad3ad5c450284819ecde191a654c09b0ec72257a2c711b9633d677c71c9850c4"
             ],
             "index": "pypi",
-            "version": "==4.0.1"
+            "version": "==4.3.1"
         },
         "requests": {
             "hashes": [
@@ -230,6 +259,22 @@
                 "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
             ],
             "version": "==2.21.0"
+        },
+        "scandir": {
+            "hashes": [
+                "sha256:2586c94e907d99617887daed6c1d102b5ca28f1085f90446554abf1faf73123e",
+                "sha256:2ae41f43797ca0c11591c0c35f2f5875fa99f8797cb1a1fd440497ec0ae4b022",
+                "sha256:2b8e3888b11abb2217a32af0766bc06b65cc4a928d8727828ee68af5a967fa6f",
+                "sha256:2c712840c2e2ee8dfaf36034080108d30060d759c7b73a01a52251cc8989f11f",
+                "sha256:4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae",
+                "sha256:67f15b6f83e6507fdc6fca22fedf6ef8b334b399ca27c6b568cbfaa82a364173",
+                "sha256:7d2d7a06a252764061a020407b997dd036f7bd6a175a5ba2b345f0a357f0b3f4",
+                "sha256:8c5922863e44ffc00c5c693190648daa6d15e7c1207ed02d6f46a8dcc2869d32",
+                "sha256:92c85ac42f41ffdc35b6da57ed991575bdbe69db895507af88b9f499b701c188",
+                "sha256:b24086f2375c4a094a6b51e78b4cf7ca16c721dcee2eddd7aa6494b42d6d519d",
+                "sha256:cb925555f43060a1745d0a321cca94bcea927c50114b623d73179189a4e100ac"
+            ],
+            "version": "==1.10.0"
         },
         "six": {
             "hashes": [
@@ -248,10 +293,10 @@
         },
         "websocket-client": {
             "hashes": [
-                "sha256:8c8bf2d4f800c3ed952df206b18c28f7070d9e3dcbd6ca6291127574f57ee786",
-                "sha256:e51562c91ddb8148e791f0155fdb01325d99bb52c4cdbb291aee7a3563fd0849"
+                "sha256:47a3ddf3ee7ecd4e2f81610bcdc7f44d5dd03b602b911d4ce991cd82310d3f3b",
+                "sha256:f6029deea21218f2c771848935aa26c15699c831770f4fa66958bdaabff80ca0"
             ],
-            "version": "==0.54.0"
+            "version": "==0.55.0"
         }
     }
 }

--- a/flask_ldapconn/__init__.py
+++ b/flask_ldapconn/__init__.py
@@ -10,7 +10,7 @@ from ldap3.core.exceptions import (LDAPBindError, LDAPInvalidFilterError,
 from ldap3.utils.dn import parse_dn
 
 from .entry import LDAPEntry
-from .attribute import LDAPAttribute
+from .attribute import LdapField
 
 
 __all__ = ('LDAPConn',)
@@ -21,7 +21,7 @@ class LDAPConn(object):
     def __init__(self, app=None):
 
         self.Entry = LDAPEntry
-        self.Attribute = LDAPAttribute
+        self.Attribute = LdapField
         self.Model = self.Entry
         self.app = app
 

--- a/flask_ldapconn/attribute.py
+++ b/flask_ldapconn/attribute.py
@@ -8,15 +8,27 @@ from ldap3 import (STRING_TYPES, NUMERIC_TYPES, MODIFY_ADD, MODIFY_DELETE,
                    MODIFY_REPLACE)
 
 
-class LDAPAttribute(object):
+class LdapField(object):
 
     def __init__(self, name, validate=None, default=None, dereference_dn=None):
+        self.name = name
+        self.validate = validate
+        self.default = default
+        self.dereference_dn = None
+
+    def get_abstract_attr_def(self, key):
+        return AttrDef(name=self.name, key=key,
+                       validate=self.validate,
+                       default=self.default,
+                       dereference_dn=self.dereference_dn)
+
+
+class LDAPAttribute(object):
+
+    def __init__(self, name):
         self.__dict__['name'] = name
         self.__dict__['values'] = []
-        self.__dict__['default'] = default
-        self.__dict__['validate'] = validate
         self.__dict__['changetype'] = None
-        self.__dict__['dereference_dn'] = dereference_dn
 
     def __str__(self):
         if isinstance(self.value, STRING_TYPES):
@@ -85,9 +97,3 @@ class LDAPAttribute(object):
         to delete.
         '''
         self.value = []
-
-    def get_abstract_attr_def(self, key):
-        return AttrDef(name=self.name, key=key,
-                       validate=self.validate,
-                       default=self.default,
-                       dereference_dn=self.dereference_dn)

--- a/flask_ldapconn/entry.py
+++ b/flask_ldapconn/entry.py
@@ -1,18 +1,13 @@
 # -*- coding: utf-8 -*-
 import json
-
-from six import add_metaclass
-from copy import deepcopy
-from importlib import import_module
-
 from flask import current_app
-from ldap3 import ObjectDef
-from ldap3.core.exceptions import LDAPAttributeError
+from six import add_metaclass
 from ldap3.utils.dn import safe_dn
 from ldap3.utils.conv import check_json_dict, format_json
+from ldap3.core.exceptions import LDAPAttributeError
 
 from .query import BaseQuery
-from .attribute import LDAPAttribute
+from .attribute import LDAPAttribute, LdapField
 
 
 __all__ = ('LDAPEntry',)
@@ -20,93 +15,44 @@ __all__ = ('LDAPEntry',)
 
 class LDAPEntryMeta(type):
 
-    # requiered
-    base_dn = None
-    entry_rdn = ['cn']
-    object_classes = ['top']
+    def __init__(cls, name, bases, attr):
+        cls._fields = {}
+        for key, value in attr.items():
+            if isinstance(value, LdapField):
+                cls._fields[key] = value
 
-    # optional
-    sub_tree = True
-    operational_attributes = False
-
-    def __init__(cls, name, bases, ns):
-        cls._attributes = dict()
-
-        # Merge attributes and object classes from parents
         for base in bases:
             if isinstance(base, LDAPEntryMeta):
-                cls._attributes.update(base._attributes)
+                cls._fields.update(base._fields)
                 # Deduplicate object classes
                 cls.object_classes = list(
                     set(cls.object_classes + base.object_classes))
-
-        # Create object definition
-        cls._object_def = ObjectDef(cls.object_classes)
-
-        # loop through the namespace looking for LDAPAttribute instances
-        for key, value in ns.items():
-            if isinstance(value, LDAPAttribute):
-                cls._attributes[key] = value
-
-        # Generate attribute definitions
-        for key in cls._attributes:
-            attr_def = cls._attributes[key].get_abstract_attr_def(key)
-            cls._object_def.add_attribute(attr_def)
 
     @property
     def query(cls):
         return BaseQuery(cls)
 
-    def get_new_type(cls):
-        class_dict = deepcopy(cls()._attributes)
-        module = import_module(cls.__module__)
-        obj = getattr(module, cls.__name__)
-        new_cls = type(cls.__name__, (obj,), class_dict)
-        return new_cls
-
 
 @add_metaclass(LDAPEntryMeta)
 class LDAPEntry(object):
 
+    base_dn = None
+    entry_rdn = ['cn']
+    object_classes = ['top']
+    sub_tree = True
+    operational_attributes = False
+    _changetype = 'add'
+
     def __init__(self, dn=None, changetype='add', **kwargs):
-        self.__dict__['_dn'] = dn
-        self.__dict__['_changetype'] = changetype
-
-        for key, value in kwargs.items():
-            if key not in self._attributes:
-                raise LDAPAttributeError('attribute not found')
-            self._attributes[key]._init = value
-
-    def __iter__(self):
-        for attribute in self._attributes:
-            yield self._attributes[attribute]
-
-    def __contains__(self, item):
-        return item in self._attributes
-
-    def __getitem__(self, item):
-        if item in self.__attributes:
-            return self.__getattr__(item)
-        else:
-            raise KeyError(item)
-
-    def __getattribute__(self, item):
-        if item != '_attributes' and item in self._attributes:
-            return self._attributes[item].value
-        else:
-            return object.__getattribute__(self, item)
-
-    def __setitem__(self, key, value):
-        if key in self._attributes:
-            self.__setattr__(key, value)
-        else:
-            raise KeyError(key)
-
-    def __setattr__(self, key, value):
-        if key in self._attributes:
-            self._attributes[key].value = value
-        else:
-            return object.__setattr__(self, key, value)
+        self._attributes = {}
+        self._dn = dn
+        self._changetype = changetype
+        if kwargs:
+            for key, value in kwargs.items():
+                self._store_attr(key, value, init=True)
+        for key, ldap_attr in self._fields.items():
+            if not self._isstored(key):
+                self._store_attr(key, [])
 
     @property
     def dn(self):
@@ -116,19 +62,56 @@ class LDAPEntry(object):
 
     def generate_dn_from_entry(self):
         rdn_list = list()
-        for attr in self._object_def:
+        for key, attr in self._attributes.items():
             if attr.name in self.entry_rdn:
-                if len(self._attributes[attr.key]) == 1:
+                if len(self._attributes[key]) == 1:
                     rdn = '{attr}={value}'.format(
                         attr=attr.name,
-                        value=self._attributes[attr.key].value
+                        value=self._attributes[key].value
                     )
                     rdn_list.append(rdn)
-
         dn = '{rdn},{base_dn}'.format(rdn='+'.join(rdn_list),
                                       base_dn=self.base_dn)
+        self._dn = safe_dn(dn)
 
-        self.__dict__['_dn'] = safe_dn(dn)
+    @classmethod
+    def _get_field(cls, attr):
+        return cls._fields.get(attr)
+
+    @classmethod
+    def _get_field_name(cls, attr):
+        if cls._get_field(attr):
+            return cls._get_field(attr).name
+
+    def _store_attr(self, attr, value=[], init=False):
+        if not self._get_field(attr):
+            raise LDAPAttributeError('attribute not found')
+        if value is None:
+            value = []
+        if not self._attributes.get(attr):
+            self._attributes[attr] = LDAPAttribute(self._get_field_name(attr))
+        self._attributes[attr].value = value
+        if init:
+            self._attributes[attr].__dict__['changetype'] = None
+
+    def _isstored(self, attr):
+        return self._attributes.get(attr)
+
+    def _get_attr(self, attr):
+        if self._isstored(attr):
+            return self._attributes[attr].value
+        return None
+
+    def __getattribute__(self, item):
+        if item != '_fields' and item in self._fields:
+            return self._get_attr(item)
+        return super(LDAPModel, self).__getattribute__(item)
+
+    def __setattr__(self, key, value):
+        if key != '_fields' and key in self._fields:
+            self._store_attr(key, value)
+        else:
+            return super(LDAPModel, self).__setattr__(key, value)
 
     def get_attributes_dict(self):
         return dict((attribute_key, attribute_value.values) for (attribute_key,
@@ -138,17 +121,15 @@ class LDAPEntry(object):
         add_dict = dict()
         for attribute_key, attribute_value in attr_dict.items():
             if self._attributes[attribute_key].value:
-                attribute_def = self._object_def[attribute_key]
-                add_dict.update({attribute_def.name: attribute_value})
+                add_dict.update({self._get_field_name(attribute_key): attribute_value})
         return add_dict
 
     def get_entry_modify_dict(self, attr_dict):
         modify_dict = dict()
         for attribute_key in attr_dict.keys():
             if self._attributes[attribute_key].changetype is not None:
-                attribute_def = self._object_def[attribute_key]
                 changes = self._attributes[attribute_key].get_changes_tuple()
-                modify_dict.update({attribute_def.name: changes})
+                modify_dict.update({self._get_field_name(attribute_key): changes})
         return modify_dict
 
     @property
@@ -161,13 +142,14 @@ class LDAPEntry(object):
 
     def save(self):
         '''Save the current instance'''
-        attributes = self.get_entry_add_dict(self.get_attributes_dict())
+        attrs = self.get_attributes_dict()
         if self._changetype == 'add':
+            changes = self.get_entry_add_dict(attrs)
             return self.connection.connection.add(self.dn,
                                                   self.object_classes,
-                                                  attributes)
+                                                  changes)
         elif self._changetype == 'modify':
-            changes = self.get_entry_modify_dict(self.get_attributes_dict())
+            changes = self.get_entry_modify_dict(attrs)
             return self.connection.connection.modify(self.dn, changes)
 
         return False

--- a/test_flask_ldapconn.py
+++ b/test_flask_ldapconn.py
@@ -15,7 +15,7 @@ from ldap3.core.exceptions import LDAPAttributeError, LDAPStartTLSError
 from flask_ldapconn import LDAPConn
 
 from flask_ldapconn.entry import LDAPEntry
-from flask_ldapconn.attribute import LDAPAttribute
+from flask_ldapconn.attribute import LdapField
 
 
 TESTING = True
@@ -55,12 +55,12 @@ class User(LDAPEntry):
     object_classes = ['inetOrgPerson']
 
     # inetOrgPerson
-    name = LDAPAttribute('cn')
-    email = LDAPAttribute('mail')
-    title = LDAPAttribute('title')
-    userid = LDAPAttribute('uid')
-    surname = LDAPAttribute('sn')
-    givenname = LDAPAttribute('givenName')
+    name = LdapField('cn')
+    email = LdapField('mail')
+    title = LdapField('title')
+    userid = LdapField('uid')
+    surname = LdapField('sn')
+    givenname = LdapField('givenName')
 
 
 class Account(User):
@@ -68,11 +68,11 @@ class Account(User):
     object_classes = ['posixAccount']
 
     # posixAccount
-    uidnumber = LDAPAttribute('uidNumber')
-    gidnumber = LDAPAttribute('gidNumber')
-    shell = LDAPAttribute('loginShell')
-    home = LDAPAttribute('homeDirectory')
-    password = LDAPAttribute('userPassword')
+    uidnumber = LdapField('uidNumber')
+    gidnumber = LdapField('gidNumber')
+    shell = LdapField('loginShell')
+    home = LdapField('homeDirectory')
+    password = LdapField('userPassword')
 
 
 class LDAPConnTestCase(unittest.TestCase):
@@ -233,23 +233,23 @@ class LDAPConnModelTestCase(unittest.TestCase):
     def test_model_iter(self):
         with self.app.test_request_context():
             user = self.user.query.filter('userid: bender').first()
-            for attr in user:
-                self.assertTrue(isinstance(attr, self.ldap.Attribute))
+            for name, field in user._fields.items():
+                self.assertTrue(isinstance(field, self.ldap.Attribute))
 
     def test_model_contains(self):
         with self.app.test_request_context():
             user = self.user.query.filter('userid: bender').first()
-            self.assertTrue('userid' in user)
+            self.assertTrue(hasattr(user, 'userid'))
 
     def test_model_getarr_att_not_found(self):
         with self.app.test_request_context():
             user = self.user.query.filter('userid: bender').first()
-            self.assertFalse('active' in user)
+            self.assertFalse(hasattr(user, 'active'))
 
-    def test_model_setitem(self):
+    def test_model_setattr(self):
         with self.app.test_request_context():
             user = self.user.query.filter('userid: fry').first()
-            user['userid'] = 'xyz'
+            user.userid = 'xyz'
             self.assertEqual(user.userid, 'xyz')
 
     def test_model_attribute_str(self):
@@ -303,7 +303,7 @@ class LDAPConnModelTestCase(unittest.TestCase):
         query_filter = 'userid: {}'.format(uid)
         with self.app.test_request_context():
             user = self.user.query.filter(query_filter).first()
-            user.delete()
+            self.assertTrue(user.delete())
             user = self.user.query.filter(query_filter).first()
             self.assertEqual(user, None)
 
@@ -358,7 +358,7 @@ class LDAPConnModelInheritanceTestCase(unittest.TestCase):
         query_filter = 'userid: {}'.format(uid)
         with self.app.test_request_context():
             user = self.user.query.filter(query_filter).first()
-            user.delete()
+            self.assertTrue(user.delete())
             user = self.user.query.filter(query_filter).first()
             self.assertEqual(user, None)
 


### PR DESCRIPTION
Wrong value obj.__class__, during creation of an object in get_new_type

Because of it pickle.dumps which is used for caching in flask-cache did not work
Selected LDAPField from LDAPAttribute that values of attributes remained in objects