### PR TITLE
fix anonymous binds (pull request #41) - Security Issue: allows authentication without password

### DIFF
--- a/flask_ldapconn/__init__.py
+++ b/flask_ldapconn/__init__.py
@@ -86,12 +86,12 @@ class LDAPConn(object):
         # Teardown appcontext
         app.teardown_appcontext(self.teardown)
 
-    def connect(self, user, password):
+    def connect(self, user, password, anonymous=False):
         auto_bind_strategy = AUTO_BIND_TLS_BEFORE_BIND
         authentication_policy = SIMPLE
         if current_app.config['LDAP_USE_TLS'] is not True:
             auto_bind_strategy = AUTO_BIND_NO_TLS
-        if current_app.config['LDAP_SECRET'] is None:
+        if anonymous:
             authentication_policy = ANONYMOUS
             user = None
             password = None
@@ -122,7 +122,8 @@ class LDAPConn(object):
             if not hasattr(ctx, 'ldap_conn'):
                 ctx.ldap_conn = self.connect(
                     current_app.config['LDAP_BINDDN'],
-                    current_app.config['LDAP_SECRET']
+                    current_app.config['LDAP_SECRET'],
+                    anonymous=None in [current_app.config['LDAP_BINDDN'], current_app.config['LDAP_SECRET']]
                 )
             return ctx.ldap_conn
 


### PR DESCRIPTION
pull request #41 introduced a very critical flaw if no `LDAP_SECRET` is configured:

- `authenticate(username, password, ...)` calls `connect(username, password)` to verify the password by executing a bind operation
- `connect(username, password)` determines that `LDAP_SECRET` is `None` and does an anonymous bind
- the anonymous bind succeeds (obviously) and thus `authenticate(username, password, ...)` returns `True` without ever verifying the credentials

In my PR I propose an optional boolean parameter `anonymous` to connect to make anonymous binds explicit (default: non-anonymous bind). That way, `authenticate(...)` always does a non-anonymous bind, because it does not pass the additional parameter. Alternatively, one could explicitly pass `anonymous=False` to be absolutely sure.

The `LDAP_SECRET is None` test is moved to the `connection` property. Add that point I added check if `LDAP_BINDDN` is `None` - if either is missing, the bind should fail - and call `connect` with `anonymous` set to True.

I have not added tests for this change, because this would probably require a reconfiguration of the LDAP-Server in the docker image to allow anonymous connections. At least my PR does not break any tests.